### PR TITLE
Gatsby installation does not need to be global (don't require sudo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Built using Gatsby and ReactJS. Deployed using Netlify 
 
-Follow the steps below to build the site locally on your machine. 
+Follow the steps below to build the site locally on your machine.
 
 1. Fork this repo
 2. git clone to a folder on your hard drive 
 3. cd into the cloned repo 
 4. Install Gatsby: 
-```npm install -g gatsby-cli```
+```npm install gatsby-cli```
 
 5. install all the npm packages ```npm install```
 6. build the site locally ```npm run develop```


### PR DESCRIPTION
By doing a global installation (i.e. `-g`) root access is required.
Removing it removes the need for `sudo`. Global installation isn't
necessary for the user to build and test the site.