### PR TITLE
adds header link to github

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -25,9 +25,14 @@ const Header = () => {
                         <Link className={headerStyles.navItem} activeClassName={headerStyles.activeNavItem} to="/posts">POSTS</Link>
                     </li>
                     <li>
-                        <a className={headerStyles.navItem} activeClassName={headerStyles.activeNavItem} href="https://opencollective.com/nannou" aria-label="Donate" target="_blank" rel="noopener noreferrer"> 
+                        <a className={headerStyles.navItem} activeClassName={headerStyles.activeNavItem} href="https://opencollective.com/nannou" aria-label="Donate" target="_blank" rel="noopener noreferrer">
                             DONATE
                         </a>
+                    </li>
+                    <li>
+                          <a className={headerStyles.navItem} activeClassName={headerStyles.activeNavItem} href="https://github.com/nannou-org/nannou" aria-label="Github" target="_blank" rel="noopener noreferrer" >
+                            CODE
+                          </a>
                     </li>
                 </ul>
             </nav>


### PR DESCRIPTION
This adds a link to the repo for Nannou to the header as `CODE`.

Also just an fyi, running `./node_modules/.bin/prettier --check **/*.js` results in many pages not conforming to prettier. I'd be happy to include that as part of this PR and squashing down.
