### PR TITLE
Update matrix links to show to space instead of deprecated group

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -34,8 +34,8 @@ const Footer = ({ data }) => {
         </a>
 
         <a
-          href="https://matrix.to/#/+nannou:matrix.org"
-          aria-label="Matrix"
+          href="https://matrix.to/#/!YGozjjyCcWclgcRQUL:matrix.org?via=matrix.org&via=fairydust.space&via=systemli.org"
+          aria-label="Matrix Space"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/components/footer_home_page.js
+++ b/src/components/footer_home_page.js
@@ -36,8 +36,8 @@ const FooterHomePage = ({ data }) => {
         </a>
 
         <a
-          href="https://matrix.to/#/+nannou:matrix.org"
-          aria-label="Matrix"
+          href="https://matrix.to/#/!YGozjjyCcWclgcRQUL:matrix.org?via=matrix.org&via=fairydust.space&via=systemli.org"
+          aria-label="Matrix Space"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -275,7 +275,7 @@ const IndexPage = ({ data }, props) => {
             <a href="https://communityinviter.com/apps/nannou/nannou-slack">
               the nannou slack
             </a> or{" "}
-            <a href="https://matrix.to/#/+nannou:matrix.org">
+            <a href="https://matrix.to/#/!YGozjjyCcWclgcRQUL:matrix.org?via=matrix.org&via=fairydust.space&via=systemli.org">
               the nannou matrix community
             </a>
             .


### PR DESCRIPTION
There is still a link at https://nannou.cc/posts/moss_grant_completion that I didn't update because I didn't know if there's a convention for marking blog post updates.